### PR TITLE
Adding new section (and reference) for Golang resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Libraries to import, export and manipulate URDF files.
 #### Julia
 - [MeshCatMechanisms.jl](https://github.com/JuliaRobotics/MeshCatMechanisms.jl) - 3D Visualization of mechanisms and URDFs using [MeshCat.jl](https://github.com/rdeits/MeshCat.jl) and [RigidBodyDynamics.jl](https://github.com/JuliaRobotics/RigidBodyDynamics.jl) . [MIT]
 
-### Go (Golang)
+#### Go (Golang)
 - [urdf-go](https://github.com/WrenchRobotics/urdf-go) - URDF parser using the XML decorators of Golang for efficient reading.
 
 ### Resources

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ See the [official ROS documentation page on URDF](http://wiki.ros.org/urdf) for 
     - [MATLAB/Simulink](#matlabsimulink)
     - [Rust](#rust)
     - [Julia](#julia)
+    - [Go](#go-golang)
   - [Resources](#resources)
   - [Extensions](#extensions)
   - [Tools](#tools)
@@ -46,6 +47,9 @@ Libraries to import, export and manipulate URDF files.
 
 #### Julia
 - [MeshCatMechanisms.jl](https://github.com/JuliaRobotics/MeshCatMechanisms.jl) - 3D Visualization of mechanisms and URDFs using [MeshCat.jl](https://github.com/rdeits/MeshCat.jl) and [RigidBodyDynamics.jl](https://github.com/JuliaRobotics/RigidBodyDynamics.jl) . [MIT]
+
+### Go (Golang)
+- [urdf-go](https://github.com/WrenchRobotics/urdf-go) - URDF parser using the XML decorators of Golang for efficient reading.
 
 ### Resources
 


### PR DESCRIPTION
Adds a new section to the readme for resources targeted to the language Go (or Golang). The resource that I wanted to point most Go users to is [urdf-go](https://github.com/WrenchRobotics/urdf-go).